### PR TITLE
Support deprecated logEvent: method

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 binary "https://raw.githubusercontent.com/UserLeap/userleap-ios-sdk-releases/main/UserLeapKit.json"
-github "mparticle/mparticle-apple-sdk" ~> 7.7.0
+github "mparticle/mparticle-apple-sdk" ~> 8.1.2

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 binary "https://raw.githubusercontent.com/UserLeap/userleap-ios-sdk-releases/main/UserLeapKit.json"
-github "mparticle/mparticle-apple-sdk" ~> 8.1.2
+github "mparticle/mparticle-apple-sdk" ~> 8.2.0

--- a/mParticle-UserLeap.podspec
+++ b/mParticle-UserLeap.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
 
     s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-UserLeap/*.{h,m}'
-    s.ios.dependency 'mParticle-Apple-SDK', '~> 8.0.1'
+    s.ios.dependency 'mParticle-Apple-SDK', '~> 8.1'
     s.ios.dependency 'UserLeapKit', '3.1.1'
 end

--- a/mParticle-UserLeap.podspec
+++ b/mParticle-UserLeap.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
 
     s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-UserLeap/*.{h,m}'
-    s.ios.dependency 'mParticle-Apple-SDK', '~> 8.1'
-    s.ios.dependency 'UserLeapKit', '3.1.1'
+    s.ios.dependency 'mParticle-Apple-SDK', '~> 8.2'
+    s.ios.dependency 'UserLeapKit', '4.1.0'
 end

--- a/mParticle-UserLeap/MPKitUserLeap.m
+++ b/mParticle-UserLeap/MPKitUserLeap.m
@@ -105,7 +105,15 @@
 
 #pragma mark Events
 
+- (nonnull MPKitExecStatus *)logEvent:(MPEvent *)event {
+    return [self _handleEvent:event];
+}
+
 - (nonnull MPKitExecStatus *)logBaseEvent:(nonnull MPBaseEvent *)event {
+    return [self _handleEvent:event];
+}
+
+- (nonnull MPKitExecStatus *)_handleEvent:(nonnull MPBaseEvent *)event {
     UIViewController *controller = event.customAttributes[@"userleap_viewcontroller"];
     BOOL showSurvey = YES;
     if (event.customAttributes[@"userleap_dont_show_survey"]) showSurvey = NO;


### PR DESCRIPTION
Even though that method is marked as deprecated in `MPKitProtocol`, it's the only one that's supported